### PR TITLE
add a universal error handler

### DIFF
--- a/liedown/api/__init__.py
+++ b/liedown/api/__init__.py
@@ -1,6 +1,7 @@
 from ..app_factory import create_app as factory_create_app
 
 from .extensions import schemas
+from .handlers import setup_handlers
 
 
 def create_app(settings_override=None):
@@ -9,5 +10,7 @@ def create_app(settings_override=None):
     extensions = frozenset([schemas])
 
     app = factory_create_app(__name__, __path__, settings_override, extensions)
+
+    setup_handlers(app)
 
     return app

--- a/liedown/api/handlers.py
+++ b/liedown/api/handlers.py
@@ -1,0 +1,9 @@
+from flask import jsonify, current_app
+
+def setup_handlers(app):
+
+    @app.errorhandler(Exception)
+    def internal_server_error(e):
+        current_app.logger.exception(e)
+        return jsonify({
+            'message': "Apologies, there's been an unexpected error."}), 500


### PR DESCRIPTION
try not to let it happen in production. a generic message is returned, and the full error is logged